### PR TITLE
CHANGE(redis): Ensure service is started or restarted at the end of role

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -19,13 +19,12 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repository
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,12 +67,34 @@
   register: _redis_conf
   tags: configure
 
-- name: restart redis
+- name: "restart redis to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_redis_namespace }}-{{ openio_redis_servicename }}
+  register: _restart_redis
   when:
-    - _redis_conf.changed or _gridinit_conf.changed
+    - _redis_conf is changed or _gridinit_conf is changed
     - not openio_redis_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure redis is started"
+      command: gridinit_cmd start {{ openio_redis_namespace }}-{{ openio_redis_servicename }}
+      register: _start_redis
+      changed_when: '"Success" in _start_redis.stdout'
+      when:
+        - not openio_redis_provision_only
+        - _restart_redis is skipped
+      tags: configure
+
+    - name: check redis
+      command: "redis-cli -h {{ openio_redis_bind_address }} -p {{ openio_redis_bind_port }} INFO"
+      register: _redis_check
+      retries: 3
+      delay: 5
+      until: _redis_check is success
+      changed_when: false
+      when:
+        - not openio_redis_provision_only
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION