### PR TITLE
BUGFIX/MINOR(redis): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,6 +11,7 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: Set system overcommit policy
   sysctl:
@@ -21,6 +22,7 @@
   when:
     - openio_redis_type == "redis"
     - ansible_virtualization_type != 'docker'
+  tags: install
 
 - name: Disable Transparent Huge Pages until reboot
   shell: "echo never > /sys/kernel/mm/transparent_hugepage/enabled && \
@@ -29,6 +31,7 @@
   when:
     - openio_redis_type == "redis"
     - ansible_virtualization_type != 'docker'
+  tags: install
 
 - name: Disable Transparent Huge Pages for next reboot
   block:
@@ -36,11 +39,13 @@
         src: disable-thp.service
         dest: /etc/systemd/system/
         mode: 644
+      tags: install
 
     - systemd:
         name: disable-thp
         enabled: true
         daemon_reload: true
+      tags: install
   when:
     - openio_redis_type == "redis"
     - ansible_virtualization_type != 'docker'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,6 +11,7 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: Set the tuned profile
   copy:
@@ -20,6 +21,7 @@
   when:
     - openio_redis_type == "redis"
     - ansible_virtualization_type != 'docker'
+  tags: install
 
 - name: Get tuned profile.
   command: /usr/sbin/tuned-adm active
@@ -29,6 +31,7 @@
   when:
     - openio_redis_type == "redis"
     - ansible_virtualization_type != 'docker'
+  tags: install
 
 - name: Set redis tuned profile.
   command: "/usr/sbin/tuned-adm profile redis"
@@ -37,4 +40,5 @@
     - openio_redis_type == "redis"
     - ansible_virtualization_type != 'docker'
     - "'redis' not in tuned_active.stdout"
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -29,7 +31,7 @@
     - path: "/var/log/oio/sds/{{ openio_redis_namespace }}/{{ openio_redis_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0770"
-  tags: install
+  tags: configure
 
 - name: Ensure Redis pid directory is persistant
   lineinfile:
@@ -39,7 +41,7 @@
     owner: openio
     group: openio
     mode: 0644
-  tags: install
+  tags: configure
   when: openio_redis_pid_directory.split(' ')[0] | dirname is match("/run/.*")
 
 - name: Generate configuration files
@@ -94,6 +96,7 @@
       delay: 5
       until: _redis_check is success
       changed_when: false
+      tags: configure
       when:
         - not openio_redis_provision_only
   when: openio_bootstrap | d(false)


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION