### PR TITLE
FEATURE(redis): Use included configuration to avoid duplicated directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,14 @@ script:
 
   # Create container and apply test playbook
   - ./docker-tests/docker-tests.sh
+  - docker exec -it $(docker ps -aq |sed '1q;d') gridinit_cmd status2
+  - docker exec -it $(docker ps -aq |sed '1q;d') /usr/bin/redis-server /etc/oio/sds/TRAVIS/redissentinel-0/redissentinel.conf --sentinel --daemonize no
   - ./docker-tests/docker-tests.sh
+  - docker exec -it $(docker ps -aq |sed '1q;d') gridinit_cmd status2
+  - docker exec -it $(docker ps -aq |sed '1q;d') /usr/bin/redis-server /etc/oio/sds/TRAVIS/redissentinel-0/redissentinel.conf --sentinel --daemonize no
   - ./docker-tests/docker-tests.sh
+  - docker exec -it $(docker ps -aq |sed '1q;d') gridinit_cmd status2
+  - docker exec -it $(docker ps -aq |sed '1q;d') /usr/bin/redis-server /etc/oio/sds/TRAVIS/redissentinel-0/redissentinel.conf --sentinel --daemonize no
 
   # Run functional tests on the container
   - SUT_ID=$(docker ps -aq |sed '1q;d') SUT_IP=172.17.0.2 ./docker-tests/functional-tests.sh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,4 +42,6 @@ openio_redis_auth_pass: ""
 openio_redis_gridinit_file_prefix: ""
 openio_redis_gridinit_dir: "/etc/gridinit.d/{{ openio_redis_namespace }}"
 openio_redis_provision_only: false
+
+openio_redis_configuration_split: true
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,29 +54,60 @@
   register: _gridinit_conf
   tags: configure
 
-- name: Generate {{ openio_redis_type }} configuration
-  lineinfile:
-    create: true
-    dest: "{{ openio_redis_sysconfig_dir }}/\
-      {{ openio_redis_servicename }}/{{ openio_redis_type }}.conf"
-    line: "{{ line }}"
-    mode: 0644
-    owner: openio
-    group: openio
-  with_items: "{{ lookup('template', openio_redis_type ~ '.conf.j2').splitlines() }}"
-  loop_control:
-    loop_var: line
-  register: _redis_conf
-  tags: configure
+- block:
+    - name: Generate {{ openio_redis_type }} configuration
+      lineinfile:
+        create: true
+        dest: "{{ openio_redis_sysconfig_dir }}/\
+          {{ openio_redis_servicename }}/{{ openio_redis_type }}.conf"
+        line: "{{ line }}"
+        mode: 0644
+        owner: openio
+        group: openio
+      with_items: "{{ lookup('template', openio_redis_type ~ '.conf.j2').splitlines() }}"
+      loop_control:
+        loop_var: line
+      register: _redis_conf
+      tags: configure
+  when: not openio_redis_configuration_split
+
+- block:
+    - name: Generate main {{ openio_redis_type }} configuration
+      lineinfile:
+        create: true
+        dest: "{{ openio_redis_sysconfig_dir }}/\
+          {{ openio_redis_servicename }}/{{ openio_redis_type }}.conf"
+        line: "include {{ openio_redis_sysconfig_dir }}/\
+          {{ openio_redis_servicename }}/{{ openio_redis_type }}-{{ openio_redis_bind_port }}.conf"
+        mode: 0644
+        owner: openio
+        group: openio
+      register: _redis_conf_main_split
+      tags: configure
+
+    - name: Generate split {{ openio_redis_type }} configuration
+      template:
+        src: "{{ openio_redis_type }}.conf.j2"
+        dest: "{{ openio_redis_sysconfig_dir }}/\
+          {{ openio_redis_servicename }}/{{ openio_redis_type }}-{{ openio_redis_bind_port }}.conf"
+        owner: openio
+        group: openio
+        mode: 0644
+      register: _redis_conf_sub_split
+      tags: configure
+  when: openio_redis_configuration_split
 
 - name: "restart redis to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_redis_namespace }}-{{ openio_redis_servicename }}
   register: _restart_redis
-  when:
-    - _redis_conf is changed or _gridinit_conf is changed
-    - not openio_redis_provision_only
+  when: >
+    (_redis_conf is changed
+    or _gridinit_conf is changed
+    or _redis_conf_main_split is changed
+    or _redis_conf_sub_split is changed)
+    and not openio_redis_provision_only
   tags: configure
 
 - block:


### PR DESCRIPTION
  ##### SUMMARY

Currently, we are forced to use `lineinfile` (instead of `template`) because the replication informations are added to the conf file by the sentinel.

But, when the first run is erroneous (example: wrong `port`): a second run doesn't fix anything.

Your final file is invalid because you have a duplicate of inconsistent instructions (here `port`)
```
[root@3d2489450bc6 /]# cat /etc/oio/sds/TRAVIS/redis-0/redis-openio.conf
daemonize no
pidfile "/run/oio/sds/TRAVIS/redis-0.pid"
port 6011 # first run
port 6379 # second run
tcp-backlog 511
…
```

This PR reduce the scope of `lineinfile` and use `template` to ensure a good configuration

OS-420
R1904-44

 ##### IMPACT
YES

Migration procedure:
- Shut one by one redis and sentinel
- Clean all conf in by `/etc/oio/sds/TRAVIS/redis-0/redis-openio.conf`
- Make sure to keep the `# Generated by CONFIG REWRITE` in the file
- Run the role (the service'll start by the `"restart redis to apply the new configuration"`)

 ##### ADDITIONAL INFORMATION
Conf splitted
```
[root@3d2489450bc6 /]# cat /etc/oio/sds/TRAVIS/redis-0/redis.conf
include /etc/oio/sds/TRAVIS/redis-0/redis-openio.conf
 # Generated by CONFIG REWRITE
pidfile "/run/oio/sds/TRAVIS/redis-0.pid"
port 6011
bind 172.17.0.4
tcp-keepalive 0
logfile "/var/log/oio/sds/TRAVIS/redis-0/redis-0.log"
save 900 1
save 300 10
save 60 10000
dir "/var/lib/oio/sds/TRAVIS/redis-0"
```

```
[root@3d2489450bc6 /]# cat /etc/oio/sds/TRAVIS/redis-0/redis-openio.conf
 # Ansible managed
daemonize no
pidfile "/run/oio/sds/TRAVIS/redis-0.pid"
port 6011
tcp-backlog 511
bind 172.17.0.4
timeout 0
tcp-keepalive 0
loglevel notice
logfile "/var/log/oio/sds/TRAVIS/redis-0/redis-0.log"
databases 16
save 900 1
save 300 10
save 60 10000
stop-writes-on-bgsave-error yes
rdbcompression yes
rdbchecksum yes
dbfilename dump.rdb
dir "/var/lib/oio/sds/TRAVIS/redis-0"
slave-serve-stale-data yes
slave-read-only yes
slave-priority 100
repl-diskless-sync no
repl-diskless-sync-delay 5
repl-disable-tcp-nodelay no
appendonly no
appendfilename "appendonly.aof"
appendfsync everysec
no-appendfsync-on-rewrite no
auto-aof-rewrite-percentage 100
auto-aof-rewrite-min-size 64mb
aof-load-truncated yes
lua-time-limit 5000
slowlog-log-slower-than 10000
slowlog-max-len 128
latency-monitor-threshold 0
notify-keyspace-events ""
hash-max-ziplist-entries 512
hash-max-ziplist-value 64
list-max-ziplist-entries 512
list-max-ziplist-value 64
set-max-intset-entries 512
zset-max-ziplist-entries 128
zset-max-ziplist-value 64
hll-sparse-max-bytes 3000
activerehashing yes
client-output-buffer-limit normal 0 0 0
client-output-buffer-limit slave 256mb 64mb 60
client-output-buffer-limit pubsub 32mb 8mb 60
hz 10
aof-rewrite-incremental-fsync yes
maxclients 10000
maxmemory 0
slaveof 172.17.0.2 6011
```