### PR TITLE
FEATURE(redis): Manage redis server `slave-priority`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,8 @@ openio_redis_master:
 
 openio_redis_tcp_backlog_queue_size: 511
 openio_redis_stacktrace_size_limit: 8192
+openio_redis_slave_priority: 100
+
 openio_redis_loglevel: notice
 openio_redis_databases: 16
 openio_redis_saves:

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -19,7 +19,7 @@ dbfilename dump.rdb
 dir "{{ openio_redis_volume }}"
 slave-serve-stale-data yes
 slave-read-only yes
-slave-priority 100
+slave-priority {{ openio_redis_slave_priority }}
 repl-diskless-sync no
 repl-diskless-sync-delay 5
 repl-disable-tcp-nodelay no


### PR DESCRIPTION
 ##### SUMMARY

This change allows to:
  - define a instance slave only
  - prior a pool of master (typically in a particular location: DC, region, ...)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://redis.io/topics/sentinel

```
Redis instances have a configuration parameter called slave-priority. This information is exposed by Redis slave instances in their INFO output, and Sentinel uses it in order to pick a slave among the ones that can be used in order to failover a master:

* If the slave priority is set to 0, the slave is never promoted to master.
* Slaves with a lower priority number are preferred by Sentinel.

For example if there is a slave S1 in the same data center of the current master, and another slave S2 in another data center, it is possible to set S1 with a priority of 10 and S2 with a priority of 100, so that if the master fails and both S1 and S2 are available, S1 will be preferred.

For more information about the way slaves are selected, please check the slave selection and priority section of this documentation.
```