### PR TITLE
BUGFIX/MAJOR(redis): Conserve role master on indempodency

### DIFF
--- a/filter_plugins/redis.py
+++ b/filter_plugins/redis.py
@@ -19,6 +19,8 @@ class FilterModule(object):
             if instance['namespace'] == namespace and instance['service'] == service:
                 if "master_host" in instance:
                     return instance[property]
+                if "role" in instance and instance['role'] == 'master':
+                    return instance.get('bind')
         return ''
 
 


### PR DESCRIPTION
 ##### SUMMARY

When the master changed, a rerun of this role set the master `slaveof` of a slave.

```
TASK [redis : set slave status on bootstrap] ***************************************************************************************************************************************************************
task path: /home/openio/git/customer-canal/deployment/sds/roles/redis/tasks/main.yml:185
Friday 23 August 2019  11:30:54 +0200 (0:00:01.129)       0:00:38.589 *********
ok: [N103] => changed=false
  attempts: 1
  mode:
    master_host: 10.206.7.6
    master_port: 6011
    status: slave
ok: [N102] => changed=false
  attempts: 1
  mode:
    master_host: 10.206.7.6
    master_port: 6011
    status: slave
ok: [N101] => changed=false
  attempts: 1
  mode:
    master_host: 10.206.7.6
    master_port: 6011
    status: slave
ok: [N201] => changed=false
  attempts: 1
  mode:
    master_host: 10.206.7.6
    master_port: 6011
    status: slave
changed: [N202] => changed=true    <<<<--- the actual master 10.206.7.6
  attempts: 1
  mode:
    master_host: 10.206.7.136     <<<<---- the original master at the installation time
    master_port: 6011
    status: slave
ok: [N203] => changed=false
  attempts: 1
  mode:
    master_host: 10.206.7.6
    master_port: 6011
    status: slave
```
 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-438