### PR TITLE
BUMP(redis): CI - Set requirements.yml to `19.10`

### DIFF
--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -23,6 +23,7 @@
 
 @test 'Sentinel voted a new  master' {
   bash -c "docker exec -ti ${SUT_ID} redis-cli -h ${SUT_IP} -p 6011 DEBUG sleep 30"
+  sleep 5
   run bash -c "docker exec -ti ${SUT_ID} redis-cli -h ${SUT_IP} -p 6012 SENTINEL get-master-addr-by-name TRAVIS-master-1 |sed -e '1q;d'|cut -d' ' -f2"
   echo "output: "$output
   echo "status: "$status

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,13 +1,13 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: "19.04"
+  version: "19.10"
   name: users
 
 - src: https://github.com/open-io/ansible-role-openio-repository.git
-  version: "19.04"
+  version: "19.10"
   name: repository
 
 - src: https://github.com/open-io/ansible-role-openio-gridinit.git
-  version: "19.04"
+  version: "19.10"
   name: gridinit
 ...


### PR DESCRIPTION
 ##### SUMMARY

In order to be able to test the roles in `19.10`, it is necessary to change the branches in this file.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION