### PR TITLE
CHANGE(redis): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ openio_redis_inventory_groupname
 | `openio_redis_tcp_keepalive` | `0` | The specified value (in seconds) is the period used to send ACKs to clients |
 | `openio_redis_timeout` | `0` | Close the connection after a client is idle for N seconds |
 | `openio_redis_volume` | `"/var/lib/oio/sds/{{ openio_redis_namespace }}/{{ openio_redis_type }}-{{ openio_redis_serviceid }}"` | The DB will be written inside this directory |
+| `openio_redis_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,7 @@ openio_redis_auth_pass: ""
 openio_redis_gridinit_file_prefix: ""
 openio_redis_gridinit_dir: "/etc/gridinit.d/{{ openio_redis_namespace }}"
 openio_redis_provision_only: false
+openio_redis_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_redis_configuration_split: true
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_redis_package_upgrade else 'present' }}"
   with_items: "{{ redis_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_redis_package_upgrade else 'present' }}"
   with_items: "{{ redis_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION