### PR TITLE
BUGFIX/MEDIUM(redis): Add timeout to fact gathering

### DIFF
--- a/files/redis.fact
+++ b/files/redis.fact
@@ -11,9 +11,12 @@ command = 'redis-server'
 oio_conf_dir = '/etc/oio/sds'
 conf_files_pattern = ['redis.conf', 'redis-*.conf']
 
+REDIS_TIMEOUT = 5
+
+
 def cmd_exists(cmd):
     return any(
-        os.access(os.path.join(path, cmd), os.X_OK) 
+        os.access(os.path.join(path, cmd), os.X_OK)
         for path in os.environ["PATH"].split(os.pathsep)
     )
 
@@ -61,7 +64,9 @@ if facts['installed']:
             try:
                 r = redis.StrictRedis(
                         host = setting['bind'],
-                        port = setting['port'])
+                        port = setting['port'],
+                        timeout = REDIS_TIMEOUT,
+                    )
                 infos = r.info()
                 setting['role'] = infos['role']
                 setting['redis_mode'] = str(infos['redis_mode'])

--- a/files/redissentinel.fact
+++ b/files/redissentinel.fact
@@ -11,9 +11,12 @@ command = 'redis-server'
 oio_conf_dir = '/etc/oio/sds'
 conf_files_pattern = ['redissentinel.conf', 'redissentinel-*.conf']
 
+REDIS_TIMEOUT = 5
+
+
 def cmd_exists(cmd):
     return any(
-        os.access(os.path.join(path, cmd), os.X_OK) 
+        os.access(os.path.join(path, cmd), os.X_OK)
         for path in os.environ["PATH"].split(os.pathsep)
     )
 
@@ -63,7 +66,9 @@ if facts['installed']:
             try:
                 r = redis.StrictRedis(
                         host = setting['bind'],
-                        port = setting['port'])
+                        port = setting['port'],
+                        timeout = REDIS_TIMEOUT,
+                    )
                 infos = r.info()
                 setting['redis_mode'] = str(infos['redis_mode'])
                 monitors = []


### PR DESCRIPTION
 ##### SUMMARY

Previously, when redis was unreachable, fact gathering would hang
forever because of an infinite timeout on StrictRedis. This sets a 5s
timeout on these requests.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION