### PR TITLE
FEATURE(redis): Allow to use AOF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   # Install latest Git

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An Ansible role for redis. Specifically, the responsibilities of this role are t
 | `openio_redis_bind_address` | `"{{ hostvars[inventory_hostname]['ansible_' + openio_redis_bind_interface]['ipv4']['address'] }}"` | The address that this redis instance will run on |
 | `openio_redis_bind_interface` | `"{{ ansible_default_ipv4.alias }}"` | The interface that this redis instance will run on |
 | `openio_redis_databases` | `16` | Set the number of databases |
-| `openio_redis_down_after` | `1000` | Number of milliseconds the master (or any attached slave or sentinel) should be unreachable |
+| `openio_redis_down_after` | `5000` | Number of milliseconds the master (or any attached slave or sentinel) should be unreachable |
 openio_redis_inventory_groupname
 | `openio_redis_inventory_groupname` | `redis` | Set your inventory groupname |
 | `openio_redis_loglevel` | `notice` | Specify the server verbosity level |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ An Ansible role for redis. Specifically, the responsibilities of this role are t
 
 | Variable   | Default | Comments (type)  |
 | :---       | :---    | :---             |
+| `openio_redis_appendonly` | `yes` | Turn on the AOF  |
+| `openio_redis_appendfilename` | `"appendonly.aof"` | The name of the append only file  |
+| `openio_redis_appendfsync` | `everysec` | Once per second, explicitly syncs write commands to disk  |
 | `openio_redis_auth_pass` | `""` | Set the password to use to authenticate with the master and slaves |
+| `openio_redis_aof_load_truncated` | `"yes"` |  Allow Redis to start without fix AOF file with `redis-check-aof`|
+| `openio_redis_aof_rewrite_incremental_fsync` | `"yes"` |  the AOF file will be fsync-ed every 32 MB of data generated |
+| `openio_redis_aof_use_rdb_preamble` | `"yes"` | Allow Redis to use an RDB preamble in the AOF file for faster rewrites and recoveries |
+| `openio_redis_auto_aof_rewrite_min_size` | `64mb` | Minimal size before rewrite the AOF file |
+| `openio_redis_auto_aof_rewrite_percentage` | `100` | Specify a percentage of zero in order to disable the automatic AOF rewrite feature |
 | `openio_redis_bind_address` | `"{{ hostvars[inventory_hostname]['ansible_' + openio_redis_bind_interface]['ipv4']['address'] }}"` | The address that this redis instance will run on |
 | `openio_redis_bind_interface` | `"{{ ansible_default_ipv4.alias }}"` | The interface that this redis instance will run on |
 | `openio_redis_databases` | `16` | Set the number of databases |
@@ -28,6 +36,7 @@ openio_redis_inventory_groupname
 | `openio_redis_master_groupname` | `"{{ openio_redis_namespace }}-master-1"` | Set of instances |
 | `openio_redis_maxclients` | `10000` | Set the max number of connected clients at the same time |
 | `openio_redis_maxmemory` | `0` | Set a memory usage limit to the specified amount of bytes |
+| `openio_redis_no_appendfsync_on_rewrite` | `"yes"` | Automatic rewrite of the append only file |
 | `openio_redis_type` | `redis` | The redis mode : `redis` or `redissentinel` |
 | `openio_redis_type_details` | `dict` | Dict of `port` and `service_name` for a `openio_redis_type` |
 | `openio_redis_namespace` | `"OPENIO"` | Namespace |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ openio_redis_maxmemory: 0
 openio_redis_master_groupname: "{{ openio_redis_namespace }}-master-1"
 openio_redis_quorum:
   "{{ ( groups[openio_redis_inventory_groupname] | length  / 2 ) | round(method='floor') | int + 1 }}"
-openio_redis_down_after: 1000
+openio_redis_down_after: 5000
 openio_redis_auth_pass: ""
 
 openio_redis_gridinit_file_prefix: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,4 +60,14 @@ openio_redis_backups: []
 #  - { "name": "weekly",  "cron": "31 2 * * sun",   "retention": "30" }
 #  - { "name": "monthly", "cron": "41 3 1 * *",     "retention": "183" }
 #  - { "name": "yearly",  "cron": "51 4 1 dec *",   "retention": "370" }
+
+openio_redis_appendonly: "yes"
+openio_redis_appendfilename: "appendonly.aof"
+openio_redis_appendfsync: everysec
+openio_redis_no_appendfsync_on_rewrite: "yes"
+openio_redis_auto_aof_rewrite_percentage: 100
+openio_redis_auto_aof_rewrite_min_size: 64mb
+openio_redis_aof_load_truncated: "yes"
+openio_redis_aof_use_rdb_preamble: "yes"
+openio_redis_aof_rewrite_incremental_fsync: "yes"
 ...

--- a/docker-tests/README.md
+++ b/docker-tests/README.md
@@ -1,12 +1,10 @@
 # Docker test environment
 
-1. Fetch the test branch: `git fetch origin docker-tests`
-2. Create a Git worktree for the test code: `git worktree add docker-tests docker-tests`. This will create a directory `docker-tests/`
-3. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/bertvv/ansible-testing/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
+1. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/bertvv/ansible-testing/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
 
     ```
-    DISTRIBUTION=centos VERSION=7 ./docker-tests/docker-tests.sh
-    DISTRIBUTION=ubuntu VERSION=16.04 ./docker-tests/docker-tests.sh
+    ANSIBLE_VERSION=2.9 DISTRIBUTION=centos VERSION=7 ./docker-tests/docker-tests.sh
+    ANSIBLE_VERSION=2.9 DISTRIBUTION=centos VERSION=7 ./docker-tests/docker-tests.sh
     ```
 
     The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,14 +3,14 @@ galaxy_info:
   author: Cedric DELGEHIER <cedric@openio.io>
   description: Install and configure a redis
   company: OpenIO
-  license: Apache
+  license: AGPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - bionic
     - name: EL
       versions:
         - 7

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -23,13 +23,15 @@ slave-priority {{ openio_redis_slave_priority }}
 repl-diskless-sync no
 repl-diskless-sync-delay 5
 repl-disable-tcp-nodelay no
-appendonly no
-appendfilename "appendonly.aof"
-appendfsync everysec
-no-appendfsync-on-rewrite no
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
-aof-load-truncated yes
+appendonly {{ openio_redis_appendonly }}
+appendfilename "{{ openio_redis_appendfilename }}"
+appendfsync {{ openio_redis_appendfsync }}
+no-appendfsync-on-rewrite {{ openio_redis_no_appendfsync_on_rewrite }}
+auto-aof-rewrite-percentage {{ openio_redis_auto_aof_rewrite_percentage }}
+auto-aof-rewrite-min-size {{ openio_redis_auto_aof_rewrite_min_size }}
+aof-load-truncated {{ openio_redis_aof_load_truncated }}
+aof-use-rdb-preamble {{ openio_redis_aof_use_rdb_preamble }}
+aof-rewrite-incremental-fsync {{ openio_redis_aof_rewrite_incremental_fsync }}
 lua-time-limit 5000
 slowlog-log-slower-than 10000
 slowlog-max-len 128


### PR DESCRIPTION
 ##### SUMMARY

By default Redis asynchronously dumps the dataset on disk.
This mode is good enough, but an issue with the Redis process may result into a few minutes of writes lost (depending on the configured save points).

The Append Only File is an alternative persistence mode that provides much better durability.

AOF and RDB persistence can be enabled at the same time without problems.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-471