### PR TITLE
BUGFIX/MEDIUM(redis): Fix redis local facts

### DIFF
--- a/files/redis.fact
+++ b/files/redis.fact
@@ -62,11 +62,19 @@ if facts['installed']:
                         if line.startswith('dir'):
                             setting['dir'] = unwrap_quotes(line)
             try:
-                r = redis.StrictRedis(
-                        host = setting['bind'],
-                        port = setting['port'],
-                        timeout = REDIS_TIMEOUT,
-                    )
+                try:
+                    r = redis.StrictRedis(
+                            host = setting['bind'],
+                            port = setting['port'],
+                            timeout = REDIS_TIMEOUT,
+                        )
+                except TypeError as e:
+                    r = redis.StrictRedis(
+                            host = setting['bind'],
+                            port = setting['port'],
+                            socket_connect_timeout = REDIS_TIMEOUT,
+                        )
+                    
                 infos = r.info()
                 setting['role'] = infos['role']
                 setting['redis_mode'] = str(infos['redis_mode'])

--- a/files/redissentinel.fact
+++ b/files/redissentinel.fact
@@ -64,11 +64,19 @@ if facts['installed']:
                         if line.startswith('sentinel auth-pass'):
                             setting['sentinel_auth-pass'] = unwrap_quotes(line)
             try:
-                r = redis.StrictRedis(
-                        host = setting['bind'],
-                        port = setting['port'],
-                        timeout = REDIS_TIMEOUT,
-                    )
+                try:
+                    r = redis.StrictRedis(
+                            host = setting['bind'],
+                            port = setting['port'],
+                            timeout = REDIS_TIMEOUT,
+                        )
+                except TypeError as e:
+                    r = redis.StrictRedis(
+                            host = setting['bind'],
+                            port = setting['port'],
+                            socket_connect_timeout = REDIS_TIMEOUT,
+                        )
+
                 infos = r.info()
                 setting['redis_mode'] = str(infos['redis_mode'])
                 monitors = []


### PR DESCRIPTION
 ##### SUMMARY

Since redis-py 2.10.0, `timeout` parameter is replaced by `socket_connect_timeout`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
__init__() got an unexpected keyword argument 'timeout'
<type 'exceptions.TypeError'>
```