### PR TITLE
CHANGE(redis): Change default of `openio_redis_down_after` from 1000 …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ openio_redis_maxmemory: 0
 openio_redis_master_groupname: "{{ openio_redis_namespace }}-master-1"
 openio_redis_quorum:
   "{{ ( groups[openio_redis_inventory_groupname] | length  / 2 ) | round(method='floor') | int + 1 }}"
-openio_redis_down_after: 1000
+openio_redis_down_after: 5000
 openio_redis_auth_pass: ""
 
 openio_redis_gridinit_file_prefix: ""


### PR DESCRIPTION
…to 5000

 ##### SUMMARY

`sentinel down-after-milliseconds OPENIO-master-1 5000`

Means server will unresponsive for 5 seconds before being classified as **+down** and consequently activating a **+vote** to elect a new master node.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OB-528