### PR TITLE
BUGFIX/MINOR(redis): Check mode on `master_host`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,14 @@
       | default(openio_redis_master.port, true) }}"
   tags: configure
 
+- name: Register master informations (check mode)
+  # check /etc/ansible/facts.d/redissentinel.fact to find the real master
+  set_fact:
+    master_host: "ip_master_check_mode"
+    master_port: 6011
+  when: ansible_check_mode
+  tags: configure
+
 - name: Ensure directories exists
   file:
     path: "{{ item.path }}"


### PR DESCRIPTION
 ##### SUMMARY

Without local facts loaded, the `master_host` is not good.

This define a placeholder to avoid misinterpretation.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION